### PR TITLE
Update NBTAPI, Spigot, and PAPI Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,19 +62,19 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.20-R0.1-SNAPSHOT</version>
+			<version>1.21.1-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>me.clip</groupId>
 			<artifactId>placeholderapi</artifactId>
-			<version>2.11.2</version>
+			<version>2.11.6</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>de.tr7zw</groupId>
 			<artifactId>item-nbt-api</artifactId>
-			<version>2.13.1</version>
+			<version>2.13.2</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
These changes, especially the NBT-API update, have been tested to allow this expansion to run on 1.21.1.